### PR TITLE
updated thefuzz version

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ All product and service names used in this page are for identification purposes 
 
 Changelog
 ==========
+v0.0.6:
+* Updated `thefuzz` version from `0.20.0` to `0.22.1`. 
 
 v0.0.5:
 * Replaced dependency: `fuzzywuzzy` with `thefuzz`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-thefuzz==0.20.0
+thefuzz==0.22.1
 PyYAML==6.0
 requests==2.31.0


### PR DESCRIPTION
Updated `thefuzz` version to `0.22.1`, MIT license.